### PR TITLE
Preserve sorted bam with duplicates marked as well as its index

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Treehouse applies a threshold of 10 million UMEND reads to triage incoming sampl
 * readDist.txt: The output of RSeqQC read_distribution.py (~1kb)
 * bam_umend_qc.tsv: uniqMappedNonDupeReadCount, estExonicUniqMappedNonDupeReadCount and PASS/FAIL
 * bam_umend_qc.json: Same as bam_umend_qc.tsv but in json format
+* sortedByCoord.md.bam: BAM with duplicates marked sorted by coordinate
+* sortedByCoord.md.bam.bai: Index for sortedByCoord.md.bam
 
 ## Running 
 via Docker:

--- a/TEST.md5
+++ b/TEST.md5
@@ -1,3 +1,5 @@
 e11b6c70f5f1ad12ea1755a5d7b9cca7  data/bam_umend_qc.json
 36a210e328bc172bb64d98e43c6d8f11  data/bam_umend_qc.tsv
 8254f8aa9f4703674187ab220f669a96  data/readDist.txt
+01e0945ee7b90e43299cdb66359579e6  data/sortedByCoord.md.bam
+898a0201d265e841f6315775adc93a09  data/sortedByCoord.md.bam.bai

--- a/run.sh
+++ b/run.sh
@@ -16,5 +16,5 @@ rm /tmp/$UUID.sortedByName.md.bam
 echo "Counting reads..."
 read_distribution.py -i /tmp/$UUID.sortedByCoord.md.bam -r /ref/hg38_GENCODE_v23_basic.bed  > $2/readDist.txt 
 Rscript --vanilla parseReadDist.R $2/readDist.txt
-rm /tmp/$UUID.sortedByCoord.md.bam
-rm /tmp/$UUID.sortedByCoord.md.bam.bai
+mv /tmp/$UUID.sortedByCoord.md.bam $2/sortedByCoord.md.bam
+mv /tmp/$UUID.sortedByCoord.md.bam.bai $2/sortedByCoord.md.bam.bai


### PR DESCRIPTION
Tiny change to umend to keep bam and bai for use by min-var-call. Look for another pull request for Treeshop that pairs with this.